### PR TITLE
Show Sicklie API sync status; Support contacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem "shoulda-matchers", "~> 6.0"
 end
 
 gem "view_component", "~> 3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (6.2.0)
+      activesupport (>= 5.2.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -268,6 +270,7 @@ DEPENDENCIES
   redis (~> 4.0)
   rspec-rails
   selenium-webdriver
+  shoulda-matchers (~> 6.0)
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails

--- a/app/components/contact_component.html.erb
+++ b/app/components/contact_component.html.erb
@@ -1,0 +1,11 @@
+<%= render CardComponent.new do %>
+  <h5 class="mb-1 text-xl font-medium text-gray-900">
+    <%= render FullNameComponent.new(@contact) %>
+  </h5>
+
+  <div class="flex mt-4 space-x-3 md:mt-6">
+    <%= form_with url: create_patient_contact_path(@contact), method: :patch do |form| %>
+      <%= form.button "Create Patient", class: "inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/contact_component.rb
+++ b/app/components/contact_component.rb
@@ -1,0 +1,5 @@
+class ContactComponent < ViewComponent::Base
+  def initialize(contact)
+    @contact = contact
+  end
+end

--- a/app/components/patient_component.html.erb
+++ b/app/components/patient_component.html.erb
@@ -1,0 +1,14 @@
+<%= render CardComponent.new do %>
+  <%= render AvatarComponent.new(avatar_url: @patient.avatar_url) %>
+  <h5 class="mb-1 text-xl font-medium text-gray-900">
+    <%= render FullNameComponent.new(@patient) %>
+  </h5>
+
+  <%= render TimestampComponent.new(@patient.sicklie_updated_at, "Not registered with Sicklie") %>
+
+  <div class="flex mt-4 space-x-3 md:mt-6">
+    <%= form_with url: sync_patient_path(@patient, redirect_path: @origin_path), method: :put do |form| %>
+      <%= form.button "Sync", class: "inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/patient_component.rb
+++ b/app/components/patient_component.rb
@@ -1,0 +1,6 @@
+class PatientComponent < ViewComponent::Base
+  def initialize(patient:, origin_path:)
+    @patient = patient
+    @origin_path = origin_path
+  end
+end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,13 @@
+class ContactsController < ApplicationController
+  def index
+    @contacts = Contact.all.includes(:patient).order(:first_name, :last_name)
+  end
+
+  def create_patient
+    @contact = Contact.find(params[:id])
+
+    @contact.create_patient!
+
+    redirect_to action: :index
+  end
+end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -12,6 +12,10 @@ class PatientsController < ApplicationController
 
     set_sicklie_sync_flash(sync_result: sync_result, patient: @patient)
 
-    redirect_to action: :index
+    if params[:redirect_path].present?
+      redirect_to params[:redirect_path]
+    else
+      redirect_to action: :index
+    end
   end
 end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,4 +1,6 @@
 class PatientsController < ApplicationController
+  include FlashHelper
+
   def index
     @patients = Patient.all.order(:first_name, :last_name)
   end
@@ -6,9 +8,10 @@ class PatientsController < ApplicationController
   def sync
     @patient = Patient.find(params[:id])
 
-    PatientSyncService.new(@patient).sync
+    sync_result = PatientSyncService.new(@patient).sync
 
-    flash[:info] = "Synced patient '#{@patient.first_name} #{@patient.last_name}' with Sicklie"
+    set_sicklie_sync_flash(sync_result: sync_result, patient: @patient)
+
     redirect_to action: :index
   end
 end

--- a/app/helpers/flash_helper.rb
+++ b/app/helpers/flash_helper.rb
@@ -1,0 +1,19 @@
+module FlashHelper
+  def set_sicklie_sync_flash(sync_result:, patient:)
+    error_prefix = "Something went wrong syncing patient '#{patient.first_name} #{patient.last_name}' with Sicklie."
+    
+    if sync_result.is_a?(String)
+      flash[:danger] = "#{error_prefix} #{sync_result}"
+    elsif sync_result.is_a?(Array)
+      errors = sync_result.map do |result| 
+        "#{result[:status_code]}: #{result[:message]}"
+      end.join("; ")
+
+      flash[:danger] = "#{error_prefix} #{errors}"
+    elsif sync_result.is_a?(Hash) && sync_result[:status_code] == "SUCCESS"
+        flash[:success] = "Success! Synced patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
+    else
+      flash[:danger] = "#{error_prefix} Unknown API error #{sync_result}"
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,22 @@
 class Contact < ApplicationRecord
+  AVATAR_URL = "https://robohash.org/quitotamnon.png?size=300x300&set=set1".freeze
+
   belongs_to :patient, optional: true
 
   validates_presence_of :first_name, :last_name
   validates_uniqueness_of :patient, allow_nil: true
+
+  def create_patient!
+    return if patient
+
+    ActiveRecord::Base.transaction do
+      patient = Patient.create!(
+        first_name: first_name,
+        last_name: last_name,
+        avatar_url: AVATAR_URL,
+      )
+
+      update!(patient: patient)
+    end
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,6 @@
+class Contact < ApplicationRecord
+  belongs_to :patient, optional: true
+
+  validates_presence_of :first_name, :last_name
+  validates_uniqueness_of :patient, allow_nil: true
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,2 +1,3 @@
 class Patient < ApplicationRecord
+  has_one :contact, dependent: :nullify
 end

--- a/app/services/patient_sync_service.rb
+++ b/app/services/patient_sync_service.rb
@@ -26,5 +26,7 @@ class PatientSyncService
         @patient.update!(sicklie_updated_at: Time.current)
       end      
     end
+
+    result
   end
 end

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,0 +1,11 @@
+<h2 class="text-lg sm:text-2xl font-extrabold">Contact Directory</h2>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 my-4 justify-items-center">
+  <% @contacts.each do |contact| %>
+    <% if contact.patient.present? %>
+      <%= render PatientComponent.new(patient: contact.patient, origin_path: contacts_path) %>
+    <% else %>
+      <%= render ContactComponent.new(contact) %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -2,19 +2,6 @@
 
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 my-4 justify-items-center">
   <% @patients.each do |patient| %>
-    <%= render CardComponent.new do %>
-      <%= render AvatarComponent.new(avatar_url: patient.avatar_url) %>
-      <h5 class="mb-1 text-xl font-medium text-gray-900">
-        <%= render FullNameComponent.new(patient) %>
-      </h5>
-      
-      <%= render TimestampComponent.new(patient.sicklie_updated_at, "Not registered with Sicklie") %>
-
-      <div class="flex mt-4 space-x-3 md:mt-6">
-        <%= form_with url: sync_patient_path(patient), method: :put do |form| %>
-          <%= form.button "Sync", class: "inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300" %>
-        <% end %>
-      </div>    
-    <% end %>
+    <%= render PatientComponent.new(patient: patient, origin_path: patients_path) %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,12 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :contacts, only: [:index] do
+    member do
+      patch :create_patient
+    end
+  end
+
   # Defines the root path route ("/")
   root "home#index"
 end

--- a/db/migrate/20240317183212_create_contacts.rb
+++ b/db/migrate/20240317183212_create_contacts.rb
@@ -1,0 +1,13 @@
+class CreateContacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contacts do |t|
+      t.references :patient, foreign_key: true, index: false
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+
+      t.timestamps
+    end
+
+    add_index :contacts, :patient_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_02_173003) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_17_183212) do
+  create_table "contacts", force: :cascade do |t|
+    t.integer "patient_id"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["patient_id"], name: "index_contacts_on_patient_id", unique: true
+  end
+
   create_table "patients", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -21,4 +30,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_173003) do
     t.datetime "sicklie_updated_at"
   end
 
+  add_foreign_key "contacts", "patients"
 end

--- a/db/seeds/contacts.rb
+++ b/db/seeds/contacts.rb
@@ -1,0 +1,7 @@
+5.times do
+  FactoryBot.create(:contact)
+end
+
+5.times do
+  FactoryBot.create(:contact, :with_patient)
+end

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe ContactsController, type: :controller do
+  describe "#index" do
+    it "succeeds" do
+      get :index
+
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "#create_patient" do
+    let(:contact) { FactoryBot.create(:contact) }
+
+    it "creates the patient for the contact and redirects" do
+      patch :create_patient, params: { id: contact.id }
+
+      expect(contact.reload.patient).to be_present
+      expect(response.status).to eq 302
+    end
+  end
+end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe PatientsController, type: :controller do
+  describe "#index" do
+    it "succeeds" do
+      get :index
+
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "#sync" do
+    let(:patient) { FactoryBot.create(:patient) }
+
+    before { allow(PatientSyncService).to receive(:new).and_call_original }
+
+    it "calls the sync service and redirects" do
+      post :sync, params: { id: patient.id }
+
+      expect(PatientSyncService).to have_received(:new)
+      expect(response.status).to eq 302
+    end
+  end
+end

--- a/spec/controllers/patients_controller_spec.rb
+++ b/spec/controllers/patients_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PatientsController, type: :controller do
     before { allow(PatientSyncService).to receive(:new).and_call_original }
 
     it "calls the sync service and redirects" do
-      post :sync, params: { id: patient.id }
+      put :sync, params: { id: patient.id }
 
       expect(PatientSyncService).to have_received(:new)
       expect(response.status).to eq 302

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :contact do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+
+    trait :with_patient do
+      patient { association :patient, first_name: first_name, last_name: last_name }
+    end
+  end
+end

--- a/spec/helpers/flash_helper_spec.rb
+++ b/spec/helpers/flash_helper_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe FlashHelper, type: :helper do
+  describe "#set_sicklie_sync_flash" do
+    let(:patient) { FactoryBot.create(:patient) }
+
+    context 'when the sync_result is a string' do
+      let(:sync_result) { "Internal server error" }
+
+      it 'sets the flash message' do
+        helper.set_sicklie_sync_flash(sync_result: sync_result, patient: patient)
+
+        expect(flash[:danger]).to eq(
+          "Something went wrong syncing patient '#{patient.first_name} #{patient.last_name}' with Sicklie. Internal server error"
+        )
+      end
+    end
+
+    context 'when the sync_result is an array of errors' do
+      let(:sync_result) do
+        [
+          { status_code: "ERROR_1", message: "Message 1" },
+          { status_code: "ERROR_2", message: "Message 2" },
+        ]
+      end
+
+      it 'sets the flash message' do
+        helper.set_sicklie_sync_flash(sync_result: sync_result, patient: patient)
+
+        expect(flash[:danger]).to eq(
+          "Something went wrong syncing patient '#{patient.first_name} #{patient.last_name}' with Sicklie. ERROR_1: Message 1; ERROR_2: Message 2"
+        )
+      end
+    end
+
+    context 'when the sync_result is a success' do
+      let(:sync_result) { { status_code: "SUCCESS", sicklie_id: SecureRandom.uuid } }
+
+      it 'sets the flash message' do
+        helper.set_sicklie_sync_flash(sync_result: sync_result, patient: patient)
+
+        expect(flash[:success]).to eq(
+          "Success! Synced patient '#{patient.first_name} #{patient.last_name}' with Sicklie"
+        )
+      end
+    end
+
+    context 'when the sync_result is not parsable' do
+      let(:sync_result) { { bad_data: "Uh oh" } }
+
+      it 'sets the flash message' do
+        helper.set_sicklie_sync_flash(sync_result: sync_result, patient: patient)
+
+        expect(flash[:danger]).to eq "Something went wrong syncing patient '#{patient.first_name} #{patient.last_name}' with Sicklie. Unknown API error {:bad_data=>\"Uh oh\"}"
+      end
+    end
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Contact, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:patient).optional }
+  end
+
+  describe "validations" do
+    let(:subject) { FactoryBot.build(:contact, :with_patient) }
+
+    it { is_expected.to validate_uniqueness_of(:patient).allow_nil }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -12,4 +12,30 @@ RSpec.describe Contact, type: :model do
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
   end
+
+  describe "create_patient!" do
+    context "when the contact already has a patient attached" do
+      let(:contact) { FactoryBot.create(:contact, :with_patient) }
+
+      it "does nothing" do
+        initial_patient_id = contact.patient_id
+
+        expect { contact.create_patient! }.not_to change(Patient, :count)
+
+        expect(contact.reload.patient_id).to eq initial_patient_id
+      end
+    end
+
+    context "when the contact does not have a patient" do
+      let(:contact) { FactoryBot.create(:contact) }
+
+      it "creates and associates the patient" do
+        expect { contact.create_patient! }.to change(Patient, :count).by(1)
+
+        expect(contact.patient.first_name).to eq contact.first_name
+        expect(contact.patient.last_name).to eq contact.last_name
+        expect(contact.patient.avatar_url).to eq Contact::AVATAR_URL
+      end
+    end
+  end
 end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Patient, type: :model do
+  it { is_expected.to have_one(:contact) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,3 +61,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/services/patient_sync_service_spec.rb
+++ b/spec/services/patient_sync_service_spec.rb
@@ -13,51 +13,104 @@ RSpec.describe PatientSyncService, type: :service do
 
     context "when the patient does NOT have a sicklie_id" do
       let(:patient_sicklie_id) { nil }
-      let(:api_response) do
-        { status_code: "SUCCESS", sicklie_id: SecureRandom.uuid }
-      end
 
       before { allow(SicklieApi).to receive(:create_patient).and_return(api_response) }
 
-      it "calls the sicklie API to create a patient" do
-        call
-        expect(SicklieApi).to have_received(:create_patient).with(
-          first_name: patient.first_name,
-          last_name: patient.last_name,
-        )
+      context "with a successful API response" do
+        let(:api_response) do
+          { status_code: "SUCCESS", sicklie_id: SecureRandom.uuid }
+        end
+
+        it "calls the sicklie API to create a patient and returns the result" do
+          result = call
+          expect(SicklieApi).to have_received(:create_patient).with(
+            first_name: patient.first_name,
+            last_name: patient.last_name,
+          )
+          expect(result[:status_code]).to eq "SUCCESS"
+          expect(result[:sicklie_id]).to be_present
+        end
+
+        it "updates the patient record" do
+          call
+          expect(patient).to have_attributes(
+            sicklie_id: api_response[:sicklie_id],
+            sicklie_updated_at: Time.current          
+          )
+        end
       end
 
-      it "updates the patient record" do
-        call
-        expect(patient).to have_attributes(
-          sicklie_id: api_response[:sicklie_id],
-          sicklie_updated_at: Time.current          
-        )
+      context 'with a failing API response' do
+        let(:api_response) { "Internal server error" }
+
+        it "calls the sicklie API to create a patient and returns the result" do
+          result = call
+          expect(SicklieApi).to have_received(:create_patient).with(
+            first_name: patient.first_name,
+            last_name: patient.last_name,
+          )
+          expect(result).to eq "Internal server error"
+        end
+
+        it "does not update the patient record" do
+          call
+          expect(patient).to have_attributes(
+            sicklie_id: nil,
+            sicklie_updated_at: nil
+          )
+        end
       end
     end
 
     context "when the patient has a sicklie_id" do
       let(:patient_sicklie_id) { SecureRandom.uuid }
-      let(:api_response) do
-        { status_code: "SUCCESS", sicklie_id: SecureRandom.uuid }
-      end
 
       before { allow(SicklieApi).to receive(:update_patient).and_return(api_response) }
 
-      it "calls the sicklie API to update a patient" do
-        call
-        expect(SicklieApi).to have_received(:update_patient).with(
-          sicklie_id: patient_sicklie_id,
-          first_name: patient.first_name,
-          last_name: patient.last_name,
-        )
+      context "with a successful API response" do
+        let(:api_response) do
+          { status_code: "SUCCESS", sicklie_id: SecureRandom.uuid }
+        end
+
+        it "calls the sicklie API to update a patient" do
+          result = call
+          expect(SicklieApi).to have_received(:update_patient).with(
+            sicklie_id: patient_sicklie_id,
+            first_name: patient.first_name,
+            last_name: patient.last_name,
+          )
+          expect(result[:status_code]).to eq "SUCCESS"
+          expect(result[:sicklie_id]).to be_present
+        end
+
+        it "updates the patient record" do
+          call
+          expect(patient).to have_attributes(
+            sicklie_updated_at: Time.current          
+          )
+        end
       end
 
-      it "updates the patient record" do
-        call
-        expect(patient).to have_attributes(
-          sicklie_updated_at: Time.current          
-        )
+      context 'with a failing API response' do
+        let(:api_response) { "Internal server error" }
+
+        it "calls the sicklie API to create a patient and returns the result" do
+          result = call
+          expect(SicklieApi).to have_received(:update_patient).with(
+            sicklie_id: patient_sicklie_id,
+            first_name: patient.first_name,
+            last_name: patient.last_name,
+          )
+          expect(result).to eq "Internal server error"
+        end
+
+        it "does not update the patient record" do
+          call
+          expect(patient).to have_attributes(
+            sicklie_id: patient_sicklie_id,
+            sicklie_updated_at: nil
+          )
+        end
       end
     end    
   end


### PR DESCRIPTION
This PR includes two main features:

**1. Show results of Sicklie API sync in the UI**
* Updates the existing `PatientSyncService` to return the status of the sync
* The flash message now shows that status after syncing a patient 

**2. Support Contacts**
* Creates a `contacts` table
* Adds a contacts index page, that shows all contacts, allows users to create patients from contacts, and shows contacts that have already been converted to patients

**Some other side effects included in this PR:**
* Adds the `shoulda-matchers` gem to support model tests 
* Refactors the Patients index page to use a `PatientComponent` 

It might be easier to review this commit-by-commit! 

**Video**
Example of all these interactions on the `/contacts` page:

https://github.com/marjielam/somersault/assets/24322833/249d53c0-2f07-4cc5-9e6b-6cdc4480b222

